### PR TITLE
fun-map.core support cljr

### DIFF
--- a/src/robertluo/fun_map/core.cljc
+++ b/src/robertluo/fun_map/core.cljc
@@ -1,23 +1,43 @@
 (ns ^:no-doc robertluo.fun-map.core
   "Where the fun starts."
-  (:import #?(:cljs nil
+  (:import #?(:cljs []
               :default [clojure.lang
                         IMapEntry
                         IPersistentMap
                         ITransientMap])))
 
-#?(:default
+#?(
 ;;Marker iterface for a funmap
-   (definterface IFunMap
-     (rawSeq []))
    :cljs
    (defprotocol  IFunMap
-     (-raw-seq [m])))
+     (-raw-seq [m]))
+   :default
+   (definterface IFunMap
+     (rawSeq [])))
 
 (declare ->DelegatedMap)
 
 ;;Support transient
-#?(:default
+#?(:cljs
+   (deftype TransientDelegatedMap [tm fn-entry]
+     ITransientMap
+     (-dissoc!
+      [_ k]
+      (TransientDelegatedMap. (-dissoc! tm k) fn-entry))
+
+     ITransientAssociative
+     (-assoc!
+      [_ k v]
+      (TransientDelegatedMap. (-assoc! tm k v) fn-entry))
+
+     ITransientCollection
+     (-persistent!
+      [_]
+      (->DelegatedMap (-persistent! tm) fn-entry))
+     (-conj!
+      [_ pair]
+      (TransientDelegatedMap. (-conj! tm pair) fn-entry)))
+   :default
    (deftype TransientDelegatedMap [^ITransientMap tm fn-entry]
      ITransientMap
      (conj [_ v] (TransientDelegatedMap. (.conj tm v) fn-entry))
@@ -45,154 +65,12 @@
      (containsKey [_ k]
        (.containsKey tm k))
      (entryAt [this k]
-       (fn-entry this (.entryAt tm k))))
-   :cljs
-   (deftype TransientDelegatedMap [tm fn-entry]
-     ITransientMap
-     (-dissoc!
-      [_ k]
-      (TransientDelegatedMap. (-dissoc! tm k) fn-entry))
+       (fn-entry this (.entryAt tm k)))))
 
-     ITransientAssociative
-     (-assoc!
-      [_ k v]
-      (TransientDelegatedMap. (-assoc! tm k v) fn-entry))
-
-     ITransientCollection
-     (-persistent!
-      [_]
-      (->DelegatedMap (-persistent! tm) fn-entry))
-     (-conj!
-      [_ pair]
-      (TransientDelegatedMap. (-conj! tm pair) fn-entry))))
-
-#?(:default
+#?(
 ;; DelegatedMap takes a map `m` and delegates most feature to it.
 ;; The magic happens on function `fn-entry`, which takes the delegated map
 ;; itself and a pair of kv as arguments. Returns a pair of kv.
-   (deftype DelegatedMap [^IPersistentMap m fn-entry]
-     IFunMap
-     (rawSeq [_]
-       (.seq m))
-     clojure.lang.MapEquivalence
-     clojure.lang.IHashEq
-     (hasheq [_]
-       (.hasheq ^clojure.lang.IHashEq m))
-     clojure.lang.IObj
-     (meta [_]
-       (.meta ^clojure.lang.IObj m))
-     (withMeta [_ mdata]
-       (DelegatedMap. (with-meta m mdata) fn-entry))
-     clojure.lang.ILookup
-     (valAt [this k]
-       (some-> ^IMapEntry (.entryAt this k) (.val)))
-     (valAt [this k not-found]
-       (if (.containsKey this k)
-         (.valAt this k)
-         not-found))
-     clojure.lang.IPersistentMap
-     (empty [_]
-       (DelegatedMap. (.empty m) fn-entry))
-     (containsKey [_ k]
-       (.containsKey m k))
-     (entryAt [this k]
-       (when (.containsKey m k)
-         (fn-entry this (.entryAt m k))))
-     (assocEx [_ k v]
-       (DelegatedMap. (.assocEx m k v) fn-entry))
-     (without [_ k]
-       (DelegatedMap. (.without m k) fn-entry))
-     #?@(:clj [(equiv [this other]
-                 (.equals this other))
-               (count [_]
-                 (.count m))
-               (cons [_ o]
-                 (DelegatedMap.
-                  (.cons m (if (instance? IFunMap o) (.rawSeq ^IFunMap o) o))
-                  fn-entry))
-               (assoc [_ k v]
-                 (DelegatedMap. (.assoc m k v) fn-entry))
-               (seq [this]
-                 (clojure.lang.IteratorSeq/create (.iterator this)))
-               (iterator [this]
-                 (let [ite (.iterator m)]
-                   (reify java.util.Iterator
-                     (hasNext [_]
-                       (.hasNext ite))
-                     (next [_]
-                       (fn-entry this (.next ite))))))
-               java.io.Closeable
-               (close
-                 [this]
-                 (when-let [close-fn (some-> this meta ::close-fn)]
-                   (close-fn this)))
-               (hashCode [_]
-                 (.hashCode m))
-               (equals [this other]
-                 (clojure.lang.APersistentMap/mapEquals this other))
-               java.util.Map
-               (size [this]
-                 (.count this))
-               (isEmpty [this]
-                 (zero? (.count this)))
-               (containsValue [this v]
-                 (boolean (some #{v} (vals this))))
-               (get [this k]
-                 (.valAt this k))
-               (keySet [this]
-                 (set (keys this)))
-               (values [this]
-                 (vals this))
-               (entrySet [this]
-                 (set this))
-               (put [_ _ _] (throw (UnsupportedOperationException.)))
-               (remove [_ _] (throw (UnsupportedOperationException.)))
-               (putAll [_ _] (throw (UnsupportedOperationException.)))
-               (clear [_] (throw (UnsupportedOperationException.)))]
-         :cljr [(equiv
-                 [this other]
-                 (.Equals this other))
-                (clojure.lang.Counted.count
-                 [_]
-                 (.count m))
-                (clojure.lang.IPersistentMap.count
-                 [_]
-                 (.count m))
-                (clojure.lang.IPersistentMap.cons
-                 [_ o]
-                 (DelegatedMap.
-                  (.cons m (if (instance? IFunMap o) (.rawSeq ^IFunMap o) o))
-                  fn-entry))
-                (clojure.lang.IPersistentMap.assoc
-                 [_ k v]
-                 (DelegatedMap. (.assoc m k v) fn-entry))
-                (seq
-                 [this]
-                 (clojure.lang.EnumeratorSeq/create (.GetEnumerator ^System.Collections.IEnumerable this)))
-                (System.Collections.IEnumerable.GetEnumerator
-                 [this]
-                 (let [ite (.GetEnumerator ^System.Collections.IEnumerable m)]
-                   (reify System.Collections.IEnumerator
-                     (MoveNext [_]
-                       (.MoveNext ite))
-                     (get_Current [_]
-                       (fn-entry this (.Current ite)))
-                     (Reset [_]
-                       (.Reset ite)))))
-                System.IDisposable
-                (Dispose
-                 [this]
-                 (when-let [close-fn (some-> this meta ::close-fn)]
-                   (close-fn this)))
-                (System.Object.GetHashCode [_] (.GetHashCode ^System.Object m))
-                (System.Object.Equals [this other] (clojure.lang.APersistentMap/mapEquals this other))
-                System.Collections.IDictionary
-                (get_Count [this] (.count m))
-                (Contains [this k] (.containsKey m k))
-                (get_Item [this k] (.valAt this k))])
-     clojure.lang.IEditableCollection
-     (asTransient [_]
-       (TransientDelegatedMap. (transient m) fn-entry)))
    :cljs
    (deftype DelegatedMap [m fn-entry]
      IFunMap
@@ -292,15 +170,139 @@
      IEditableCollection
      (-as-transient
        [_]
-       (TransientDelegatedMap. (-as-transient m) fn-entry))))
+       (TransientDelegatedMap. (-as-transient m) fn-entry)))
+   :default
+   (deftype DelegatedMap [^IPersistentMap m fn-entry]
+     IFunMap
+     (rawSeq [_]
+       (.seq m))
+     clojure.lang.MapEquivalence
+     clojure.lang.IHashEq
+     (hasheq [_]
+       (.hasheq ^clojure.lang.IHashEq m))
+     clojure.lang.IObj
+     (meta [_]
+       (.meta ^clojure.lang.IObj m))
+     (withMeta [_ mdata]
+       (DelegatedMap. (with-meta m mdata) fn-entry))
+     clojure.lang.ILookup
+     (valAt [this k]
+       (some-> ^IMapEntry (.entryAt this k) (.val)))
+     (valAt [this k not-found]
+       (if (.containsKey this k)
+         (.valAt this k)
+         not-found))
+     clojure.lang.IEditableCollection
+     (asTransient [_]
+       (TransientDelegatedMap. (transient m) fn-entry))
+     clojure.lang.IPersistentMap
+     (empty [_]
+       (DelegatedMap. (.empty m) fn-entry))
+     (containsKey [_ k]
+       (.containsKey m k))
+     (entryAt [this k]
+       (when (.containsKey m k)
+         (fn-entry this (.entryAt m k))))
+     (assocEx [_ k v]
+       (DelegatedMap. (.assocEx m k v) fn-entry))
+     (without [_ k]
+       (DelegatedMap. (.without m k) fn-entry))
+     #?@(:clj [(equiv [this other]
+                 (.equals this other))
+               (count [_]
+                 (.count m))
+               (cons [_ o]
+                 (DelegatedMap.
+                  (.cons m (if (instance? IFunMap o) (.rawSeq ^IFunMap o) o))
+                  fn-entry))
+               (assoc [_ k v]
+                 (DelegatedMap. (.assoc m k v) fn-entry))
+               (seq [this]
+                 (clojure.lang.IteratorSeq/create (.iterator this)))
+               (iterator [this]
+                 (let [ite (.iterator m)]
+                   (reify java.util.Iterator
+                     (hasNext [_]
+                       (.hasNext ite))
+                     (next [_]
+                       (fn-entry this (.next ite))))))
+               java.io.Closeable
+               (close
+                 [this]
+                 (when-let [close-fn (some-> this meta ::close-fn)]
+                   (close-fn this)))
+               (hashCode [_]
+                 (.hashCode m))
+               (equals [this other]
+                 (clojure.lang.APersistentMap/mapEquals this other))
+               java.util.Map
+               (size [this]
+                 (.count this))
+               (isEmpty [this]
+                 (zero? (.count this)))
+               (containsValue [this v]
+                 (boolean (some #{v} (vals this))))
+               (get [this k]
+                 (.valAt this k))
+               (keySet [this]
+                 (set (keys this)))
+               (values [this]
+                 (vals this))
+               (entrySet [this]
+                 (set this))
+               (put [_ _ _] (throw (UnsupportedOperationException.)))
+               (remove [_ _] (throw (UnsupportedOperationException.)))
+               (putAll [_ _] (throw (UnsupportedOperationException.)))
+               (clear [_] (throw (UnsupportedOperationException.)))]
+         :cljr [(equiv
+                 [this other]
+                 (.Equals this other))
+                (clojure.lang.Counted.count
+                 [_]
+                 (.count m))
+                (clojure.lang.IPersistentMap.count
+                 [_]
+                 (.count m))
+                (clojure.lang.IPersistentMap.cons
+                 [_ o]
+                 (DelegatedMap.
+                  (.cons m (if (instance? IFunMap o) (.rawSeq ^IFunMap o) o))
+                  fn-entry))
+                (clojure.lang.IPersistentMap.assoc
+                 [_ k v]
+                 (DelegatedMap. (.assoc m k v) fn-entry))
+                (seq
+                 [this]
+                 (clojure.lang.EnumeratorSeq/create (.GetEnumerator ^System.Collections.IEnumerable this)))
+                (System.Collections.IEnumerable.GetEnumerator
+                 [this]
+                 (let [ite (.GetEnumerator ^System.Collections.IEnumerable m)]
+                   (reify System.Collections.IEnumerator
+                     (MoveNext [_]
+                       (.MoveNext ite))
+                     (get_Current [_]
+                       (fn-entry this (.Current ite)))
+                     (Reset [_]
+                       (.Reset ite)))))
+                System.IDisposable
+                (Dispose
+                 [this]
+                 (when-let [close-fn (some-> this meta ::close-fn)]
+                   (close-fn this)))
+                (System.Object.GetHashCode [_] (.GetHashCode ^System.Object m))
+                (System.Object.Equals [this other] (clojure.lang.APersistentMap/mapEquals this other))
+                System.Collections.IDictionary
+                (get_Count [this] (.count m))
+                (Contains [this k] (.containsKey m k))
+                (get_Item [this k] (.valAt this k))])))
 
 (defn- fn-entry-adapter
   "turns function `fn-entry` to entry in/out function"
   [fn-entry]
   (fn [m ^IMapEntry entry]
     (when-let [[k v] (fn-entry m entry)]
-      #?(:default (clojure.lang.MapEntry/create k v)
-         :cljs (cljs.core/MapEntry. k v nil)))))
+      #?(:cljs (cljs.core/MapEntry. k v nil)
+         :default (clojure.lang.MapEntry/create k v)))))
 
 (defn delegate-map
   "Return a delegated map"
@@ -309,8 +311,8 @@
 
 (defn fun-map?
   [o]
-  #?(:default (instance? IFunMap o)
-     :cljs (satisfies? IFunMap o)))
+  #?(:cljs (satisfies? IFunMap o)
+     :default (instance? IFunMap o)))
 
 #?(:clj
    (do

--- a/src/robertluo/fun_map/core.cljc
+++ b/src/robertluo/fun_map/core.cljc
@@ -185,7 +185,11 @@
                  (when-let [close-fn (some-> this meta ::close-fn)]
                    (close-fn this)))
                 (System.Object.GetHashCode [_] (.GetHashCode ^System.Object m))
-                (System.Object.Equals [this other] (clojure.lang.APersistentMap/mapEquals this other))])
+                (System.Object.Equals [this other] (clojure.lang.APersistentMap/mapEquals this other))
+                System.Collections.IDictionary
+                (get_Count [this] (.count m))
+                (Contains [this k] (.containsKey m k))
+                (get_Item [this k] (.valAt this k))])
      clojure.lang.IEditableCollection
      (asTransient [_]
        (TransientDelegatedMap. (transient m) fn-entry)))


### PR DESCRIPTION
以clj的实现为基础移植到cljr中。原clj实现作为默认实现（default），默认实现中无法与cljr兼容的部分，再引入cljr的特殊实现。目前合计两处cljr分支。

测试用例已在clj、cljs、cljr下分别跑通。