### PR TITLE
fun map support cljr

### DIFF
--- a/src/robertluo/fun_map/core.cljc
+++ b/src/robertluo/fun_map/core.cljc
@@ -268,9 +268,15 @@
                  (DelegatedMap.
                   (.cons m (if (instance? IFunMap o) (.rawSeq ^IFunMap o) o))
                   fn-entry))
+                (clojure.lang.IPersistentCollection.cons
+                 [this o]
+                 (.cons ^IPersistentMap this o))
                 (clojure.lang.IPersistentMap.assoc
                  [_ k v]
                  (DelegatedMap. (.assoc m k v) fn-entry))
+                (clojure.lang.Associative.assoc
+                 [this k v]
+                 (.assoc ^IPersistentMap this k v))
                 (seq
                  [this]
                  (clojure.lang.EnumeratorSeq/create (.GetEnumerator ^System.Collections.IEnumerable this)))

--- a/src/robertluo/fun_map/helper.cljc
+++ b/src/robertluo/fun_map/helper.cljc
@@ -1,7 +1,6 @@
 (ns robertluo.fun-map.helper
   "Helpers for writing wrappers"
-  (:require
-   #?(:clj [robertluo.fun-map.util :as util])))
+   #?(:clj (:require [robertluo.fun-map.util :as util])))
 
 #?(:clj
    (defn let-form
@@ -18,7 +17,7 @@
               vec)]
         [`let bindings])
       [`let bindings]))
-   :cljs
+   :default
    (defn let-form
      [_ bindings]
      [`let bindings]))

--- a/src/robertluo/fun_map/wrapper.cljc
+++ b/src/robertluo/fun_map/wrapper.cljc
@@ -9,7 +9,8 @@
     "unwrap the real value from a wrapper on the key of k"))
 
 ;; Make sure common value is not wrapped
-#?(:clj
+#?(:cljs nil
+   :default
    (extend-protocol ValueWrapper
      Object
      (-wrapped? [_ _] false)
@@ -45,15 +46,15 @@
   "returns a k,v pair from map `m` and input k-v pair.
    If `v` is a wrapped, then recursive unwrap it."
   [m [k v]]
-  #?(:clj
-     (if (-wrapped? v m)
-       (recur m [k (-unwrap v m k)])
-       [k v])
-     :cljs
+  #?(:cljs
      (cond
        (satisfies? ValueWrapper v) (recur m [k (-unwrap v m k)])
        (satisfies? IDeref v) (recur m [k (deref v)])
-       :else [k v])))
+       :else [k v])
+     :default
+     (if (-wrapped? v m)
+       (recur m [k (-unwrap v m k)])
+       [k v])))
 
 ;;;;;;;;;;; High order wrappers
 


### PR DESCRIPTION
* 以clj的实现为基础移植到cljr。原clj实现作为默认实现（default），其与cljr基本兼容。
* 唯一的例外是：`fun-map.helper` 的 `let-form` 中，clj下会额外尝试引入`mainfold.deferred`空间并处理。此处cljr的实现与cljs保存一致，即不做额外处理。
* 测试用例已在clj、cljs、cljr下分别跑通。